### PR TITLE
Fix syntax error

### DIFF
--- a/addons/SA_AdvancedSlingLoading/config.cpp
+++ b/addons/SA_AdvancedSlingLoading/config.cpp
@@ -32,7 +32,7 @@ class CfgFunctions
 		class AdvancedSlingLoading
 		{
 			file = "\SA_AdvancedSlingLoading\functions";
-			class advancedSlingLoadingInit{postInit=1};
+			class advancedSlingLoadingInit{postInit=1;};
 		};
 	};
 };


### PR DESCRIPTION
File sa_advancedslingloading\config.cpp, line 34: '/CfgFunctions/SA/AdvancedSlingLoading/advancedSlingLoadingInit.postInit': Missing ';' prior '}'