### PR TITLE
Pass the correct vehicle rope index to ASL_Drop_Ropes

### DIFF
--- a/addons/SA_AdvancedSlingLoading/functions/fn_advancedSlingLoadingInit.sqf
+++ b/addons/SA_AdvancedSlingLoading/functions/fn_advancedSlingLoadingInit.sqf
@@ -753,7 +753,7 @@ ASL_Attach_Ropes = {
 				if( _objDistance > _ropeLength ) then {
 					[["The cargo ropes are too short. Move vehicle closer.", false],"ASL_Hint",_player] call ASL_RemoteExec;
 				} else {		
-					[_vehicle,_player] call ASL_Drop_Ropes;
+					[_vehicle,_player,(_vehicleWithIndex select 1)] call ASL_Drop_Ropes;
 					[_cargo, _attachmentPoints select 0, [0,0,-1]] ropeAttachTo (_ropes select 0);
 					[_cargo, _attachmentPoints select 1, [0,0,-1]] ropeAttachTo (_ropes select 1);
 					[_cargo, _attachmentPoints select 2, [0,0,-1]] ropeAttachTo (_ropes select 2);


### PR DESCRIPTION
Default rope index "0" was used, and it prevented players from attaching cargo to ropes with indices >= 1.

This fixes the problem where players can't attach more than one cargo even on helicopter that double or triple slingload capacity.

Fixes #28 